### PR TITLE
Enhance Visit model with additional medical details

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -40,6 +40,11 @@ public interface Logic {
     ObservableList<Visit> getFilteredVisitList();
 
     /**
+     * Returns an unmodifiable view of the sorted list of visits
+     */
+    ObservableList<Visit> getSortedVisitList();
+
+    /**
      * Returns the user prefs' Med Logger file path.
      */
     Path getMedLoggerFilePath();

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -78,6 +78,11 @@ public class LogicManager implements Logic {
     }
 
     @Override
+    public ObservableList<Visit> getSortedVisitList() {
+        return model.getSortedVisitList();
+    }
+
+    @Override
     public Path getMedLoggerFilePath() {
         return model.getMedLoggerFilePath();
     }

--- a/src/main/java/seedu/address/logic/commands/AddVisitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddVisitCommand.java
@@ -2,9 +2,13 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DIAGNOSIS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FOLLOWUP;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MEDICATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SYMPTOM;
 
 import java.util.Optional;
 
@@ -19,22 +23,32 @@ import seedu.address.model.person.Visit;
  */
 public class AddVisitCommand extends Command {
     public static final String COMMAND_WORD = "visit";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + "Add a visit to MedLogger. "
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a visit to MedLogger.\n"
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_NRIC + "NRIC "
-            + PREFIX_DATE + "DATE "
-            + PREFIX_REMARK + "REMARK"
+            + "[" + PREFIX_DATE + "DATE_TIME] "
+            + PREFIX_REMARK + "REMARK "
+            + PREFIX_SYMPTOM + "SYMPTOM "
+            + PREFIX_DIAGNOSIS + "DIAGNOSIS "
+            + PREFIX_MEDICATION + "MEDICATION "
+            + PREFIX_FOLLOWUP + "FOLLOWUP\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_NRIC + "S1234567A "
-            + PREFIX_DATE + "2024-12-31 11:11 "
-            + PREFIX_REMARK + "Headache";
+            + PREFIX_REMARK + "Headache "
+            + PREFIX_SYMPTOM + "Headache "
+            + PREFIX_DIAGNOSIS + "Migraine "
+            + PREFIX_MEDICATION + "Panadol "
+            + PREFIX_FOLLOWUP + "In 1 week";
+
     public static final String MESSAGE_SUCCESS = "New visit recorded: %1$s";
     public static final String MESSAGE_DUPLICATE_VISIT = "This visit already exists in the MedLogger";
     public static final String MESSAGE_NO_PERSON_FOR_VISIT = "The person in this visit does not exist in the MedLogger";
 
     private Visit visit;
+
     /**
      * Creates an AddVisitCommand to add the specified {@code Visit}
      */
@@ -46,14 +60,25 @@ public class AddVisitCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
         Optional<Person> optionalPerson = model.getPersonByNric(visit.getNric());
 
-        if (optionalPerson.isPresent()) {
-            Person person = optionalPerson.get();
-            this.visit = new Visit(person, visit.getDateTime(), visit.getRemark());
-        } else {
+        if (optionalPerson.isEmpty()) {
             throw new CommandException(MESSAGE_NO_PERSON_FOR_VISIT);
         }
+
+        Person person = optionalPerson.get();
+
+        // Replace the visit's person with the actual one from model
+        this.visit = new Visit(
+                person,
+                visit.getDateTime(),
+                visit.getRemark(),
+                visit.getSymptom(),
+                visit.getDiagnosis(),
+                visit.getMedication(),
+                visit.getFollowUp()
+        );
 
         if (model.hasVisit(visit)) {
             throw new CommandException(MESSAGE_DUPLICATE_VISIT);

--- a/src/main/java/seedu/address/logic/commands/EditVisitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditVisitCommand.java
@@ -2,8 +2,12 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DIAGNOSIS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FOLLOWUP;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MEDICATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SYMPTOM;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
@@ -38,12 +42,20 @@ public class EditVisitCommand extends Command {
             + "by the index number used in the displayed visit list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_NRIC + "Nric] "
+            + "[" + PREFIX_NRIC + "NRIC] "
             + "[" + PREFIX_DATE + "DATE] "
             + "[" + PREFIX_REMARK + "REMARK] "
+            + "[" + PREFIX_SYMPTOM + "SYMPTOM] "
+            + "[" + PREFIX_DIAGNOSIS + "DIAGNOSIS] "
+            + "[" + PREFIX_MEDICATION + "MEDICATION] "
+            + "[" + PREFIX_FOLLOWUP + "FOLLOWUP] \n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_NRIC + "S1234567A "
-            + PREFIX_DATE + "2011-11-11 11:11";
+            + PREFIX_DATE + "2025-04-04 15:00 "
+            + PREFIX_REMARK + "Improved "
+            + PREFIX_SYMPTOM + "Fever "
+            + PREFIX_DIAGNOSIS + "Flu "
+            + PREFIX_MEDICATION + "Paracetamol "
+            + PREFIX_FOLLOWUP + "1 week";
 
     public static final String MESSAGE_EDIT_VISIT_SUCCESS = "Edited Visit: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/seedu/address/logic/commands/EditVisitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditVisitCommand.java
@@ -17,9 +17,13 @@ import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.DateTime;
+import seedu.address.model.person.Diagnosis;
+import seedu.address.model.person.FollowUp;
+import seedu.address.model.person.Medication;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Remark;
+import seedu.address.model.person.Symptom;
 import seedu.address.model.person.Visit;
 
 
@@ -98,14 +102,19 @@ public class EditVisitCommand extends Command {
      * edited with {@code editVisitDescriptor}.
      */
     private static Visit createEditedVisit(Person person, Visit visitToEdit,
-                                           EditVisitDescriptor editVisitDescriptor) {
-        assert visitToEdit != null;
+            EditVisitDescriptor editVisitDescriptor) {
 
+        assert visitToEdit != null;
         DateTime updatedDateTime = editVisitDescriptor.getDateTime().orElse(visitToEdit.getDateTime());
         Remark updatedRemark = editVisitDescriptor.getRemark().orElse(visitToEdit.getRemark());
-
-        return new Visit(person, updatedDateTime, updatedRemark);
+        Symptom updatedSymptom = editVisitDescriptor.getSymptom().orElse(visitToEdit.getSymptom());
+        Diagnosis updatedDiagnosis = editVisitDescriptor.getDiagnosis().orElse(visitToEdit.getDiagnosis());
+        Medication updatedMedication = editVisitDescriptor.getMedication().orElse(visitToEdit.getMedication());
+        FollowUp updatedFollowUp = editVisitDescriptor.getFollowUp().orElse(visitToEdit.getFollowUp());
+        return new Visit(person, updatedDateTime, updatedRemark, updatedSymptom,
+                updatedDiagnosis, updatedMedication, updatedFollowUp);
     }
+
 
     @Override
     public boolean equals(Object other) {
@@ -139,6 +148,10 @@ public class EditVisitCommand extends Command {
         private Nric nric;
         private DateTime dateTime;
         private Remark remark;
+        private Symptom symptom;
+        private Diagnosis diagnosis;
+        private Medication medication;
+        private FollowUp followUp;
 
         public EditVisitDescriptor() {}
 
@@ -155,7 +168,7 @@ public class EditVisitCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(nric, dateTime, remark);
+            return CollectionUtil.isAnyNonNull(nric, dateTime, remark, symptom, diagnosis, medication, followUp);
         }
 
         public void setNric(Nric nric) {
@@ -180,6 +193,35 @@ public class EditVisitCommand extends Command {
 
         public Optional<Remark> getRemark() {
             return Optional.ofNullable(remark);
+        }
+
+        // Setters and Getters
+        public void setSymptom(Symptom symptom) {
+            this.symptom = symptom;
+        }
+        public Optional<Symptom> getSymptom() {
+            return Optional.ofNullable(symptom);
+        }
+
+        public void setDiagnosis(Diagnosis diagnosis) {
+            this.diagnosis = diagnosis;
+        }
+        public Optional<Diagnosis> getDiagnosis() {
+            return Optional.ofNullable(diagnosis);
+        }
+
+        public void setMedication(Medication medication) {
+            this.medication = medication;
+        }
+        public Optional<Medication> getMedication() {
+            return Optional.ofNullable(medication);
+        }
+
+        public void setFollowUp(FollowUp followUp) {
+            this.followUp = followUp;
+        }
+        public Optional<FollowUp> getFollowUp() {
+            return Optional.ofNullable(followUp);
         }
 
         @Override

--- a/src/main/java/seedu/address/logic/commands/ListVisitsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListVisitsCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import seedu.address.model.Model;
+import seedu.address.model.person.Nric;
 
 /**
  * Lists all visits in the Med Logger to the user.
@@ -10,16 +11,31 @@ import seedu.address.model.Model;
 public class ListVisitsCommand extends Command {
 
     public static final String COMMAND_WORD = "listvisits";
-
     public static final String MESSAGE_SUCCESS = "Listed all visits";
+    public static final String MESSAGE_USAGE = "listvisits [i/NRIC] [l/LIMIT]";
 
-    public static final String MESSAGE_USAGE = "listvisits l/LIMIT";
+    private final Nric nric;
+    private final Integer limit;
 
-    private Integer limit;
+    /**
+     * Creates a ListVisitsCommand to list all visits.
+     * thus no NRIC or limit is provided.
+     */
+    public ListVisitsCommand() {
+        this.nric = null;
+        this.limit = null;
+    }
 
-    public ListVisitsCommand() {}
-
-    public ListVisitsCommand(int limit) {
+    /**
+     * Creates a ListVisitsCommand to list only visits
+     * with the specified NRIC and limit.
+     * Both parameters are optional.
+     *
+     * @param nric the NRIC of the person whose visits to list
+     * @param limit the maximum number of visits to list
+     */
+    public ListVisitsCommand(Nric nric, Integer limit) {
+        this.nric = nric;
         this.limit = limit;
     }
 
@@ -27,14 +43,19 @@ public class ListVisitsCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
 
-        if (this.limit == null) {
-            model.updateFilteredVisitList(visit -> true); // Show all
-            return new CommandResult(MESSAGE_SUCCESS);
+        // Apply NRIC filter if provided
+        if (nric != null) {
+            model.updateFilteredVisitList(visit -> visit.getNric().equals(nric));
         } else {
-            model.updateSubFilteredVisitList(this.limit);
-            int numOfVisits = Math.min(this.limit, model.getFilteredVisitList().size());
-            return new CommandResult("Listed " + numOfVisits + " visits");
+            model.updateFilteredVisitList(v -> true);
         }
+
+        // Apply limit if provided
+        if (limit != null) {
+            model.updateSubFilteredVisitList(limit); // assumes sub-listing is after main filtering
+            return new CommandResult("Listed " + Math.min(limit, model.getFilteredVisitList().size()) + " visits");
+        }
+
+        return new CommandResult(MESSAGE_SUCCESS);
     }
 }
-

--- a/src/main/java/seedu/address/logic/commands/SortVisitsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortVisitsCommand.java
@@ -4,8 +4,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Comparator;
 
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
 import seedu.address.model.Model;
 import seedu.address.model.person.Visit;
 
@@ -28,16 +26,12 @@ public class SortVisitsCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
 
-        ObservableList<Visit> currentList = FXCollections.observableArrayList(model.getFilteredVisitList());
-
         Comparator<Visit> comparator = Comparator.comparing((Visit v) -> v.getDateTime().toLocalDateTime());
-        
         if (isDescending) {
             comparator = comparator.reversed();
         }
 
-        currentList.sort(comparator);
-        model.updateFilteredVisitList(currentList::contains);
+        model.sortFilteredVisitList(comparator);
 
         return new CommandResult(isDescending ? MESSAGE_SUCCESS_DESC : MESSAGE_SUCCESS_ASC);
     }

--- a/src/main/java/seedu/address/logic/commands/SortVisitsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortVisitsCommand.java
@@ -1,0 +1,46 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Comparator;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.address.model.Model;
+import seedu.address.model.person.Visit;
+
+/**
+ * Sorts the currently visible visit list by visit dateTime.
+ */
+public class SortVisitsCommand extends Command {
+
+    public static final String COMMAND_WORD = "sortvisits";
+    public static final String MESSAGE_SUCCESS_ASC = "Sorted visits by date and time (ascending).";
+    public static final String MESSAGE_SUCCESS_DESC = "Sorted visits by date and time (descending).";
+
+    private final boolean isDescending;
+
+    public SortVisitsCommand(boolean isDescending) {
+        this.isDescending = isDescending;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+
+        ObservableList<Visit> currentList = FXCollections.observableArrayList(model.getFilteredVisitList());
+
+        Comparator<Visit> comparator = (v1, v2) -> 
+            v1.getDateTime().toString().compareTo(v2.getDateTime().toString());
+        if (isDescending) {
+            comparator = comparator.reversed();
+        }
+
+        currentList.sort(comparator);
+        model.updateFilteredVisitList(currentList::contains);
+
+        return new CommandResult(isDescending ? MESSAGE_SUCCESS_DESC : MESSAGE_SUCCESS_ASC);
+    }
+}
+
+

--- a/src/main/java/seedu/address/logic/commands/SortVisitsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortVisitsCommand.java
@@ -30,7 +30,7 @@ public class SortVisitsCommand extends Command {
 
         ObservableList<Visit> currentList = FXCollections.observableArrayList(model.getFilteredVisitList());
 
-        Comparator<Visit> comparator = (v1, v2) -> 
+        Comparator<Visit> comparator = (v1, v2) ->
             v1.getDateTime().toString().compareTo(v2.getDateTime().toString());
         if (isDescending) {
             comparator = comparator.reversed();

--- a/src/main/java/seedu/address/logic/commands/SortVisitsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortVisitsCommand.java
@@ -30,8 +30,8 @@ public class SortVisitsCommand extends Command {
 
         ObservableList<Visit> currentList = FXCollections.observableArrayList(model.getFilteredVisitList());
 
-        Comparator<Visit> comparator = (v1, v2) ->
-            v1.getDateTime().toString().compareTo(v2.getDateTime().toString());
+        Comparator<Visit> comparator = Comparator.comparing((Visit v) -> v.getDateTime().toLocalDateTime());
+        
         if (isDescending) {
             comparator = comparator.reversed();
         }

--- a/src/main/java/seedu/address/logic/parser/AddVisitCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddVisitCommandParser.java
@@ -67,7 +67,7 @@ public class AddVisitCommandParser implements Parser<AddVisitCommand> {
             dateTime = new DateTime(dateInput);
         } else {
             dateTime = DateTime.now(); // Use current time if not specified
-        }        
+        }
 
         // Optional visit fields
         Symptom symptom = new Symptom(argMultimap.getValue(PREFIX_SYMPTOM).orElse("N/A"));

--- a/src/main/java/seedu/address/logic/parser/AddVisitCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddVisitCommandParser.java
@@ -2,9 +2,13 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DIAGNOSIS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FOLLOWUP;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MEDICATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SYMPTOM;
 
 import java.util.HashSet;
 import java.util.stream.Stream;
@@ -13,14 +17,17 @@ import seedu.address.logic.commands.AddVisitCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.DateTime;
+import seedu.address.model.person.Diagnosis;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.FollowUp;
+import seedu.address.model.person.Medication;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Remark;
+import seedu.address.model.person.Symptom;
 import seedu.address.model.person.Visit;
-import seedu.address.model.tag.Tag;
 
 
 
@@ -35,10 +42,13 @@ public class AddVisitCommandParser implements Parser<AddVisitCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public AddVisitCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_NRIC, PREFIX_DATE, PREFIX_REMARK);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(
+                args,
+                PREFIX_NAME, PREFIX_NRIC, PREFIX_DATE, PREFIX_REMARK,
+                PREFIX_SYMPTOM, PREFIX_DIAGNOSIS, PREFIX_MEDICATION, PREFIX_FOLLOWUP
+        );
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_NRIC, PREFIX_DATE, PREFIX_REMARK)
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_NRIC, PREFIX_REMARK)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddVisitCommand.MESSAGE_USAGE));
         }
@@ -46,10 +56,29 @@ public class AddVisitCommandParser implements Parser<AddVisitCommand> {
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Nric nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
         Remark remark = ParserUtil.parseRemark(argMultimap.getValue(PREFIX_REMARK).get());
-        DateTime dateTime = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
-        Person person = new Person(name, nric, Phone.DUMMY_PHONE, Email.DUMMY_EMAIL,
-                Address.DUMMY_ADDRESS, new Remark(""), new HashSet<Tag>());
-        Visit visit = new Visit(person, dateTime, remark);
+
+        // Optional date
+        DateTime dateTime;
+        if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
+            String dateInput = argMultimap.getValue(PREFIX_DATE).get();
+            if (!DateTime.isValidDate(dateInput)) {
+                throw new ParseException(DateTime.MESSAGE_CONSTRAINTS);
+            }
+            dateTime = new DateTime(dateInput);
+        } else {
+            dateTime = DateTime.now(); // Use current time if not specified
+        }        
+
+        // Optional visit fields
+        Symptom symptom = new Symptom(argMultimap.getValue(PREFIX_SYMPTOM).orElse("N/A"));
+        Diagnosis diagnosis = new Diagnosis(argMultimap.getValue(PREFIX_DIAGNOSIS).orElse("N/A"));
+        Medication medication = new Medication(argMultimap.getValue(PREFIX_MEDICATION).orElse("N/A"));
+        FollowUp followUp = new FollowUp(argMultimap.getValue(PREFIX_FOLLOWUP).orElse("N/A"));
+
+        Person dummyPerson = new Person(name, nric, Phone.DUMMY_PHONE, Email.DUMMY_EMAIL,
+                Address.DUMMY_ADDRESS, new Remark(""), new HashSet<>());
+
+        Visit visit = new Visit(dummyPerson, dateTime, remark, symptom, diagnosis, medication, followUp);
         return new AddVisitCommand(visit);
     }
 

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -15,4 +15,10 @@ public class CliSyntax {
     public static final Prefix PREFIX_REMARK = new Prefix("r/");
     public static final Prefix PREFIX_DATE = new Prefix("d/");
     public static final Prefix PREFIX_LIMIT = new Prefix("l/");
+
+    /* For visits */
+    public static final Prefix PREFIX_SYMPTOM = new Prefix("sym/");
+    public static final Prefix PREFIX_DIAGNOSIS = new Prefix("diag/");
+    public static final Prefix PREFIX_MEDICATION = new Prefix("med/");
+    public static final Prefix PREFIX_FOLLOWUP = new Prefix("f/");
 }

--- a/src/main/java/seedu/address/logic/parser/ListVisitsCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListVisitsCommandParser.java
@@ -2,9 +2,11 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LIMIT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 
 import seedu.address.logic.commands.ListVisitsCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Nric;
 
 /**
  * Parses input arguments and creates a new {@code ListVisitsCommand} object.
@@ -19,22 +21,24 @@ public class ListVisitsCommandParser {
      * @throws ParseException If the input does not conform to the expected format.
      */
     public ListVisitsCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NRIC, PREFIX_LIMIT);
 
-        if (args.trim().isEmpty()) {
-            return new ListVisitsCommand();
+        Nric nric = null;
+        Integer limit = null;
+
+        if (argMultimap.getValue(PREFIX_NRIC).isPresent()) {
+            nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
         }
 
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_LIMIT);
-
-        int limit;
-
-        try {
-            limit = Integer.parseInt(argMultimap.getValue(PREFIX_LIMIT).orElse(""));
-        } catch (NumberFormatException ive) {
-            throw new ParseException(String.format(
-                MESSAGE_INVALID_COMMAND_FORMAT, ListVisitsCommand.MESSAGE_USAGE), ive);
+        if (argMultimap.getValue(PREFIX_LIMIT).isPresent()) {
+            try {
+                limit = Integer.parseInt(argMultimap.getValue(PREFIX_LIMIT).get());
+            } catch (NumberFormatException e) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        ListVisitsCommand.MESSAGE_USAGE), e);
+            }
         }
 
-        return new ListVisitsCommand(limit);
+        return new ListVisitsCommand(nric, limit);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/MedLoggerParser.java
+++ b/src/main/java/seedu/address/logic/parser/MedLoggerParser.java
@@ -21,6 +21,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RemarkCommand;
+import seedu.address.logic.commands.SortVisitsCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -92,6 +93,9 @@ public class MedLoggerParser {
 
         case ClearVisitsCommand.COMMAND_WORD:
             return new ClearVisitsCommand();
+
+        case SortVisitsCommand.COMMAND_WORD:
+            return new SortVisitsCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/SortVisitsCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortVisitsCommandParser.java
@@ -1,0 +1,17 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.SortVisitsCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses arguments for the sortVisits command.
+ */
+public class SortVisitsCommandParser implements Parser<SortVisitsCommand> {
+
+    @Override
+    public SortVisitsCommand parse(String args) throws ParseException {
+        String trimmed = args.trim().toLowerCase();
+        boolean isDescending = trimmed.equals("desc");
+        return new SortVisitsCommand(isDescending);
+    }
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -112,6 +113,8 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredVisitList(Predicate<Visit> predicate);
+
+    void sortFilteredVisitList(Comparator<Visit> comparator);
 
     void updateSubFilteredPersonList(int n);
     int size();

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -136,5 +136,7 @@ public interface Model {
      */
     void updateSubFilteredVisitList(int n);
 
+    ObservableList<Visit> getSortedVisitList();
+
     int size();
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,8 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -174,6 +176,20 @@ public class ModelManager implements Model {
 
         filteredPersons.setPredicate(limitedList::contains);
     }
+
+    /**
+     * Sorts the filtered visit list based on the provided comparator.
+     * To force the filtered list to update, we create a new list and set the predicate to
+     *
+     * @param comparator The comparator to sort the visits.
+     */
+    @Override
+    public void sortFilteredVisitList(Comparator<Visit> comparator) {
+        List<Visit> sortedList = new ArrayList<>(filteredVisits);
+        sortedList.sort(comparator);
+        filteredVisits.setPredicate(sortedList::contains); // triggers update
+    }
+
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -14,6 +13,7 @@ import java.util.stream.Collectors;
 
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import javafx.collections.transformation.SortedList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Nric;
@@ -30,6 +30,7 @@ public class ModelManager implements Model {
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
     private final FilteredList<Visit> filteredVisits;
+    private final SortedList<Visit> sortedVisits;
 
 
     /**
@@ -44,6 +45,7 @@ public class ModelManager implements Model {
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.medLogger.getPersonList());
         filteredVisits = new FilteredList<>(this.medLogger.getVisitList());
+        sortedVisits = new SortedList<>(filteredVisits);
     }
 
     public ModelManager() {
@@ -195,9 +197,7 @@ public class ModelManager implements Model {
      */
     @Override
     public void sortFilteredVisitList(Comparator<Visit> comparator) {
-        List<Visit> sortedList = new ArrayList<>(filteredVisits);
-        sortedList.sort(comparator);
-        filteredVisits.setPredicate(sortedList::contains); // triggers update
+        sortedVisits.setComparator(comparator);
     }
 
 
@@ -227,6 +227,11 @@ public class ModelManager implements Model {
                 && filteredPersons.equals(otherModelManager.filteredPersons)
                 && filteredVisits.equals(otherModelManager.filteredVisits);
 
+    }
+
+    @Override
+    public ObservableList<Visit> getSortedVisitList() {
+        return sortedVisits;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/DateTime.java
+++ b/src/main/java/seedu/address/model/person/DateTime.java
@@ -51,6 +51,14 @@ public class DateTime {
         }
     }
 
+    /**
+     * Returns true if a given string is a valid date in yyyy-mm-dd HH:mm format.
+     */
+    public LocalDateTime toLocalDateTime() {
+        return LocalDateTime.parse(value, FORMATTER);
+    }
+
+
     @Override
     public String toString() {
         return value;

--- a/src/main/java/seedu/address/model/person/DateTime.java
+++ b/src/main/java/seedu/address/model/person/DateTime.java
@@ -58,6 +58,14 @@ public class DateTime {
         return LocalDateTime.parse(value, FORMATTER);
     }
 
+    /**
+     * Returns the current date and time in the format yyyy-mm-dd HH:mm.
+     * @return The current date and time
+     */
+    public static DateTime now() {
+        return new DateTime(LocalDateTime.now().format(FORMATTER));
+    }
+
 
     @Override
     public String toString() {

--- a/src/main/java/seedu/address/model/person/Diagnosis.java
+++ b/src/main/java/seedu/address/model/person/Diagnosis.java
@@ -1,0 +1,32 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Represents the doctor's diagnosis for a visit.
+ */
+public class Diagnosis {
+    public final String value;
+
+    public Diagnosis(String value) {
+        requireNonNull(value);
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this
+                || (other instanceof Diagnosis
+                && value.equals(((Diagnosis) other).value));
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/model/person/Diagnosis.java
+++ b/src/main/java/seedu/address/model/person/Diagnosis.java
@@ -8,6 +8,11 @@ import static java.util.Objects.requireNonNull;
 public class Diagnosis {
     public final String value;
 
+    /**
+     * Constructs a {@code Diagnosis}.
+     *
+     * @param value Some diagnosis.
+     */
     public Diagnosis(String value) {
         requireNonNull(value);
         this.value = value;

--- a/src/main/java/seedu/address/model/person/FollowUp.java
+++ b/src/main/java/seedu/address/model/person/FollowUp.java
@@ -1,0 +1,32 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Represents follow-up information (e.g., review in 1 week).
+ */
+public class FollowUp {
+    public final String value;
+
+    public FollowUp(String value) {
+        requireNonNull(value);
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this
+                || (other instanceof FollowUp
+                && value.equals(((FollowUp) other).value));
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/model/person/FollowUp.java
+++ b/src/main/java/seedu/address/model/person/FollowUp.java
@@ -8,6 +8,11 @@ import static java.util.Objects.requireNonNull;
 public class FollowUp {
     public final String value;
 
+    /**
+     * Constructs a {@code FollowUp}.
+     *
+     * @param value Some follow-up information.
+     */
     public FollowUp(String value) {
         requireNonNull(value);
         this.value = value;

--- a/src/main/java/seedu/address/model/person/Medication.java
+++ b/src/main/java/seedu/address/model/person/Medication.java
@@ -1,0 +1,32 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Represents medication prescribed to the patient.
+ */
+public class Medication {
+    public final String value;
+
+    public Medication(String value) {
+        requireNonNull(value);
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this
+                || (other instanceof Medication
+                && value.equals(((Medication) other).value));
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/model/person/Medication.java
+++ b/src/main/java/seedu/address/model/person/Medication.java
@@ -8,6 +8,11 @@ import static java.util.Objects.requireNonNull;
 public class Medication {
     public final String value;
 
+    /**
+     * Constructs a {@code Medication}.
+     *
+     * @param value Some medication.
+     */
     public Medication(String value) {
         requireNonNull(value);
         this.value = value;

--- a/src/main/java/seedu/address/model/person/Symptom.java
+++ b/src/main/java/seedu/address/model/person/Symptom.java
@@ -1,0 +1,32 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Represents the patient's symptom.
+ */
+public class Symptom {
+    public final String value;
+
+    public Symptom(String value) {
+        requireNonNull(value);
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this
+                || (other instanceof Symptom
+                && value.equals(((Symptom) other).value));
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/model/person/Symptom.java
+++ b/src/main/java/seedu/address/model/person/Symptom.java
@@ -8,6 +8,10 @@ import static java.util.Objects.requireNonNull;
 public class Symptom {
     public final String value;
 
+    /**
+     * Constructs a {@code Symptom}.
+     * @param value some symptom.
+     */
     public Symptom(String value) {
         requireNonNull(value);
         this.value = value;

--- a/src/main/java/seedu/address/model/person/Visit.java
+++ b/src/main/java/seedu/address/model/person/Visit.java
@@ -2,11 +2,14 @@ package seedu.address.model.person;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.time.LocalDateTime;
-
 import seedu.address.commons.util.ToStringBuilder;
 
+/**
+ * Represents a Visit of a particular Person.
+ * Guarantees: details are present and not null, field values are validated, immutable.
+ */
 public class Visit {
+    // Visit details: who, when, why, how
     private final Person person;
     private final DateTime dateTime;
     private final Remark remark;
@@ -15,6 +18,12 @@ public class Visit {
     private final Medication medication;
     private final FollowUp followUp;
 
+    /**
+     * Every parameter must present and be non-null.
+     * @param person
+     * @param dateTime
+     * @param remark
+     */
     public Visit(Person person, DateTime dateTime, Remark remark,
                  Symptom symptom, Diagnosis diagnosis,
                  Medication medication, FollowUp followUp) {
@@ -66,8 +75,12 @@ public class Visit {
 
     @Override
     public boolean equals(Object other) {
-        if (other == this) return true;
-        if (!(other instanceof Visit)) return false;
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof Visit)) {
+            return false;
+        }
         Visit o = (Visit) other;
         return person.equals(o.person)
                 && dateTime.equals(o.dateTime)

--- a/src/main/java/seedu/address/model/person/Visit.java
+++ b/src/main/java/seedu/address/model/person/Visit.java
@@ -1,74 +1,93 @@
 package seedu.address.model.person;
+
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.time.LocalDateTime;
 
 import seedu.address.commons.util.ToStringBuilder;
 
-/**
- * Represents a Visit of a particular Person.
- * Guarantees: details are present and not null, field values are validated, immutable.
- */
 public class Visit {
-    // Visit details: who, when, why
     private final Person person;
     private final DateTime dateTime;
     private final Remark remark;
+    private final Symptom symptom;
+    private final Diagnosis diagnosis;
+    private final Medication medication;
+    private final FollowUp followUp;
 
-    /**
-     * Every parameter must present and be non-null.
-     * @param person
-     * @param dateTime
-     * @param remark
-     */
-    public Visit(Person person, DateTime dateTime, Remark remark) {
-        requireAllNonNull(person, dateTime, remark);
+    public Visit(Person person, DateTime dateTime, Remark remark,
+                 Symptom symptom, Diagnosis diagnosis,
+                 Medication medication, FollowUp followUp) {
+        requireAllNonNull(person, remark, symptom, diagnosis, medication, followUp);
         this.person = person;
-        this.dateTime = dateTime;
+        this.dateTime = (dateTime != null) ? dateTime : DateTime.now();
         this.remark = remark;
+        this.symptom = symptom;
+        this.diagnosis = diagnosis;
+        this.medication = medication;
+        this.followUp = followUp;
     }
 
     public Person getPerson() {
-        return this.person;
+        return person;
     }
 
     public Nric getNric() {
-        return this.person.getNric();
-    }
-
-    public Remark getRemark() {
-        return this.remark;
+        return person.getNric();
     }
 
     public DateTime getDateTime() {
-        return this.dateTime;
+        return dateTime;
     }
 
-    public Visit withPerson(Person person) {
-        return new Visit(person, dateTime, remark);
+    public Remark getRemark() {
+        return remark;
     }
 
-    /**
-     * Returns true if and only if the other object is an instance of Visit
-     * and the other visit has same visit details.
-     */
+    public Symptom getSymptom() {
+        return symptom;
+    }
+
+    public Diagnosis getDiagnosis() {
+        return diagnosis;
+    }
+
+    public Medication getMedication() {
+        return medication;
+    }
+
+    public FollowUp getFollowUp() {
+        return followUp;
+    }
+
+    public Visit withPerson(Person newPerson) {
+        return new Visit(newPerson, dateTime, remark, symptom, diagnosis, medication, followUp);
+    }
+
     @Override
-    public boolean equals(Object object) {
-        if (object == this) {
-            return true;
-        } else if (object instanceof Visit other) {
-            return other.person.equals(this.person)
-                    && other.dateTime.equals(this.dateTime)
-                    && other.remark.equals(this.remark);
-        } else {
-            return false;
-        }
+    public boolean equals(Object other) {
+        if (other == this) return true;
+        if (!(other instanceof Visit)) return false;
+        Visit o = (Visit) other;
+        return person.equals(o.person)
+                && dateTime.equals(o.dateTime)
+                && remark.equals(o.remark)
+                && symptom.equals(o.symptom)
+                && diagnosis.equals(o.diagnosis)
+                && medication.equals(o.medication)
+                && followUp.equals(o.followUp);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
                 .add("person", person)
-                .add("visit time", dateTime)
+                .add("dateTime", dateTime)
                 .add("remark", remark)
+                .add("symptom", symptom)
+                .add("diagnosis", diagnosis)
+                .add("medication", medication)
+                .add("followUp", followUp)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedVisit.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedVisit.java
@@ -4,15 +4,18 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.person.Address;
 import seedu.address.model.person.DateTime;
+import seedu.address.model.person.Diagnosis;
+import seedu.address.model.person.FollowUp;
+import seedu.address.model.person.Medication;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Remark;
+import seedu.address.model.person.Symptom;
 import seedu.address.model.person.Visit;
 
 /**
- * Jackson-friendly version of {@link Person}.
+ * Jackson-friendly version of {@link Visit}.
  */
 class JsonAdaptedVisit {
 
@@ -22,25 +25,42 @@ class JsonAdaptedVisit {
     private final String dateTime;
     private final String remark;
 
+    private final String symptom;
+    private final String diagnosis;
+    private final String medication;
+    private final String followUp;
 
     /**
-     * Constructs a {@code JsonAdaptedPerson} with the given person details.
+     * Constructs a {@code JsonAdaptedVisit} with the given visit details.
      */
     @JsonCreator
-    public JsonAdaptedVisit(@JsonProperty("NRIC") String nric, @JsonProperty("dateTime") String dateTime,
-                            @JsonProperty("remark") String remark) {
+    public JsonAdaptedVisit(@JsonProperty("NRIC") String nric,
+                            @JsonProperty("dateTime") String dateTime,
+                            @JsonProperty("remark") String remark,
+                            @JsonProperty("symptom") String symptom,
+                            @JsonProperty("diagnosis") String diagnosis,
+                            @JsonProperty("medication") String medication,
+                            @JsonProperty("followUp") String followUp) {
         this.nric = nric;
         this.dateTime = dateTime;
         this.remark = remark;
+        this.symptom = symptom;
+        this.diagnosis = diagnosis;
+        this.medication = medication;
+        this.followUp = followUp;
     }
 
     /**
-     * Converts a given {@code Person} into this class for Jackson use.
+     * Converts a given {@code Visit} into this class for Jackson use.
      */
     public JsonAdaptedVisit(Visit source) {
         nric = source.getNric().value;
         dateTime = source.getDateTime().value;
         remark = source.getRemark().value;
+        symptom = source.getSymptom().value;
+        diagnosis = source.getDiagnosis().value;
+        medication = source.getMedication().value;
+        followUp = source.getFollowUp().value;
     }
 
     public Nric getNric() throws IllegalValueException {
@@ -54,25 +74,34 @@ class JsonAdaptedVisit {
     }
 
     /**
-     * Converts this Jackson-friendly adapted person object into the model's {@code Person} object.
+     * Converts this Jackson-friendly adapted visit object into the model's {@code Visit} object.
      *
-     * @throws IllegalValueException if there were any data constraints violated in the adapted person.
+     * @throws IllegalValueException if there were any data constraints violated in the adapted visit.
      */
     public Visit toModelType(Person person) throws IllegalValueException {
+        // Handle dateTime
+        final DateTime modelDateTime;
         if (dateTime == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName()));
-        }
-        if (!DateTime.isValidDate(dateTime)) {
+            modelDateTime = DateTime.now();
+        } else if (!DateTime.isValidDate(dateTime)) {
             throw new IllegalValueException(DateTime.MESSAGE_CONSTRAINTS);
+        } else {
+            modelDateTime = new DateTime(dateTime);
         }
-        final DateTime modelDateTime = new DateTime(dateTime);
 
+        // Handle remark
         if (remark == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Remark.class.getSimpleName()));
         }
         final Remark modelRemark = new Remark(remark);
 
-        return new Visit(person, modelDateTime, modelRemark);
-    }
+        // Handle optional fields with fallback
+        final Symptom modelSymptom = new Symptom(symptom != null ? symptom : "N/A");
+        final Diagnosis modelDiagnosis = new Diagnosis(diagnosis != null ? diagnosis : "N/A");
+        final Medication modelMedication = new Medication(medication != null ? medication : "N/A");
+        final FollowUp modelFollowUp = new FollowUp(followUp != null ? followUp : "N/A");
 
+        return new Visit(person, modelDateTime, modelRemark,
+                modelSymptom, modelDiagnosis, modelMedication, modelFollowUp);
+    }
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -117,7 +117,7 @@ public class MainWindow extends UiPart<Stage> {
         personListPanel = new PersonListPanel(logic.getFilteredPersonList());
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
-        visitListPanel = new VisitListPanel(logic.getFilteredVisitList());
+        visitListPanel = new VisitListPanel(logic.getSortedVisitList());
         visitListPanelPlaceholder.getChildren().add(visitListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();

--- a/src/test/java/seedu/address/logic/commands/AddPersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddPersonCommandTest.java
@@ -219,6 +219,11 @@ public class AddPersonCommandTest {
         public void sortFilteredVisitList(Comparator<Visit> comparator) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public ObservableList<Visit> getSortedVisitList() {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddPersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddPersonCommandTest.java
@@ -10,6 +10,7 @@ import static seedu.address.testutil.TypicalPersons.ALICE;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -27,6 +28,7 @@ import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Visit;
 import seedu.address.testutil.PersonBuilder;
+
 
 public class AddPersonCommandTest {
 
@@ -195,6 +197,11 @@ public class AddPersonCommandTest {
 
         @Override
         public int size() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void sortFilteredVisitList(Comparator<Visit> comparator) {
             throw new AssertionError("This method should not be called.");
         }
     }


### PR DESCRIPTION
- Added new fields to Visit: symptom, diagnosis, medication, and followUp
- Made dateTime optional during visit creation (defaults to current time)
- Updated AddVisitCommand, EditVisitCommand, and related storage logic to support the new fields
- Added new CLI prefixes: s/, dg/, m/, and f/ for the respective fields

closes #94 