### PR TITLE
Fix bug deleting a person does not delete the visits of the person

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditPersonCommand.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 

--- a/src/main/java/seedu/address/logic/commands/EditPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditPersonCommand.java
@@ -49,7 +49,6 @@ public class EditPersonCommand extends Command {
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
-            + "[" + PREFIX_REMARK + "REMARK] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "

--- a/src/main/java/seedu/address/model/person/PersonVisitDictionary.java
+++ b/src/main/java/seedu/address/model/person/PersonVisitDictionary.java
@@ -100,11 +100,12 @@ public class PersonVisitDictionary {
         if (!personToVisits.containsKey(target)) {
             throw new PersonNotFoundException();
         }
+        List<Visit> targetPersonVisits = personToVisits.get(target);
+        personToVisits.remove(target);
         addPerson(editedPerson);
-        for (Visit visit : personToVisits.get(target)) {
+        for (Visit visit : targetPersonVisits) {
             personToVisits.get(editedPerson).add(visit.withPerson(editedPerson));
         }
-        personToVisits.remove(target);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/PersonVisitDictionary.java
+++ b/src/main/java/seedu/address/model/person/PersonVisitDictionary.java
@@ -26,6 +26,7 @@ public class PersonVisitDictionary {
      */
     public void setDictionary(Map<Person, List<Visit>> personToVisits) {
         requireNonNull(personToVisits);
+        this.personToVisits.clear();
         for (Map.Entry<Person, List<Visit>> entry : personToVisits.entrySet()) {
             this.personToVisits.put(entry.getKey(), new ArrayList<>(entry.getValue()));
         }

--- a/src/main/java/seedu/address/model/person/PersonVisitDictionary.java
+++ b/src/main/java/seedu/address/model/person/PersonVisitDictionary.java
@@ -100,11 +100,11 @@ public class PersonVisitDictionary {
         if (!personToVisits.containsKey(target)) {
             throw new PersonNotFoundException();
         }
-        personToVisits.remove(target);
         addPerson(editedPerson);
-        for (Visit visit : personToVisits.get(editedPerson)) {
+        for (Visit visit : personToVisits.get(target)) {
             personToVisits.get(editedPerson).add(visit.withPerson(editedPerson));
         }
+        personToVisits.remove(target);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -89,6 +89,7 @@ public class UniquePersonList implements Iterable<Person> {
     public void setPersons(UniquePersonList replacement) {
         requireNonNull(replacement);
         internalList.setAll(replacement.internalList);
+        personMap.clear();
         personMap.putAll(replacement.personMap);
     }
 
@@ -102,6 +103,7 @@ public class UniquePersonList implements Iterable<Person> {
             throw new DuplicatePersonException();
         }
         internalList.setAll(persons);
+        personMap.clear();
         for (Person person : persons) {
             personMap.put(person.getNric().value, person);
         }


### PR DESCRIPTION
This bug is caused by clear the current data. Before this fix, clear will reset persons and visits list and dictionary of Medlloger to that of a new Medlogger. The reset logic of visits and persons are clear current list and copy from new list, but the reset logic of dictionary is copy key-value pairs of new dictionary to current dictionary. This means after clear, dictionary still holds old key-value pairs, hence leading to bug after inserting person with duplicate details after clear.